### PR TITLE
Updated build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ sourceSets {
 }
 
 def runeLiteVersion = '1.8.11'
-def osrsbotVersion = '0.0.7'
+def osrsbotVersion = '0.0.8'
 def daxWalkerVersion = '0.0.3'
 
 


### PR DESCRIPTION
I was having issues with using the Gradle task "launchClientWithScript" launching an old version of the client that didn't support reloading and wasn't loading scripts properly. Found the previous version was hardcoded. Not 100% sure if there is a way to change it with updates dynamically, but I figured I'd help with this issue for now with a bandaid so people don't have to search for it themselves or just not use the helpful feature if they happen to be using the script template.